### PR TITLE
Optionally hide the CMD key icon

### DIFF
--- a/admin_keyboard_shortcuts/templates/admin/base_site.html
+++ b/admin_keyboard_shortcuts/templates/admin/base_site.html
@@ -4,7 +4,7 @@
 {% block title %}{{ title }} | {% trans 'Django site admin' %}{% endblock %}
 
 {% block branding %}
-<h1 id="site-name">{% trans 'Django administration' %} {% if "maybe"|display_keyboard_icon %}<img src="{% static "admin_keyboard_shortcuts/CMD-Key-icon.png" %}">{% endif %}</h1>
+<h1 id="site-name">{% trans 'Django administration' %} {% if "maybe"|display_cmd_key_icon %}<img src="{% static "admin_keyboard_shortcuts/CMD-Key-icon.png" %}">{% endif %}</h1>
 <script type="text/javascript">
 django.jQuery(document).keydown(function(e) {
     if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey))

--- a/admin_keyboard_shortcuts/templatetags/admin_keyboard_shortcuts_tags.py
+++ b/admin_keyboard_shortcuts/templatetags/admin_keyboard_shortcuts_tags.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.filter
-def display_keyboard_icon(dummy):
-    if hasattr(settings, 'HIDE_KEYBOARD_SHORTCUT_ICON') and settings.HIDE_KEYBOARD_SHORTCUT_ICON:
+def display_cmd_key_icon(dummy):
+    if hasattr(settings, 'ADMIN_KEYBOARD_SHORTCUTS_HIDE_ICON') and settings.ADMIN_KEYBOARD_SHORTCUTS_HIDE_ICON:
         return False
     return True


### PR DESCRIPTION
I really like the idea of adding keyboard shortcuts to the admin, but I'm not too much a fan of the conspicuous CMD key icon on every page of the admin. 

With this PR it hides the icon if you set `ADMIN_KEYBOARD_SHORTCUTS_HIDE_ICON=True` in your project settings (it's still visible by default)
